### PR TITLE
Update README with operating notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,3 +225,158 @@ This framework represents a fundamental rethinking of physics based on timing co
 ---
 
 **Ready to explore the information-theoretic foundations of reality through Euclidean Timing Mechanics!** 🚀
+## Repository Context and Environment
+
+The following notes describe the development approach and example setup. Feel free to run simulations with as many nodes as your hardware comfortably supports. Pushing the limits helps refine ETM theory in the `docs/etm_theory` folder and ensures the logic and particle definitions remain rigorous and reproducible.
+**Always run simulations with as many nodes as your system comfortably allows. Larger lattices provide better insight into ETM dynamics.**
+
+```text
+Some things to keep in mind:
+
+Different chats will run different tests, potentially involving different modules.  After results are interpreted from a test, there might be adjustments to script; these adjustments might sometimes have to be implemented across the script of many modules or even the script of all modules.  So each chat needs to have access to the etm_theory_foundation_outline.txt, which is in the etm_theory directory, which is in the docs directory.  This will be kept updated such that it rigorously, formally, completely, accurately, and precisely defines the current state of the logic of ETM, such that human beings and AI could read this document, and use it to write code that duplicates all work in ETM.  This summary must have the axioms, rules, definitions and particle identities, and logical flow all presented in a way consistent with professional journals on logic, particle physics, and computer programming.  If this document is kept updated properly, then independent chats running different modules and exploring different subsections of physics and ETM, will still be united in focus because of this document.  The README file in the main directory must explain how the modular system works to simulate particle physics in ETM.  Remember that the script must be set up such that any results (.json files, for example) are summarized in an appropriate way so that needed information is not lost, yet the files are small enough to function properly on my home computing system (details below), small enough to be easily uploaded to online AI, and small enough that specific AI chats can utilize and converse about the files without a problem.  All these statements apply to individual script files as well. 
+
+On the other hand, simulations must NOT be over-simplified to the point that they do not represent reality accurately.  The compromise we generally approximately operate at now, to be consistent with the abilities of a typical home computing system, is a simulation containing approximately 27000 nodes in a 30*30*30 lattice.  This may be adjusted as is appropriate.  Later versions of ETM, I assume, will be hosted online with adequate computing power to effectively model very large interactions of complex molecules, and also duplicate high energy accelerator experiments.
+
+
+Here is my home computer set up:
+
+Device name	DESKTOP-TLPVA1N
+Processor	Intel(R) Pentium(R) Gold G6400 CPU @ 4.00GHz   4.01 GHz
+Installed RAM	16.0 GB (15.8 GB usable)
+Device ID	FC30A3AE-DA77-490A-9A71-DC155AC164BB
+Product ID	00325-81844-07958-AAOEM
+System type	64-bit operating system, x64-based processor
+Pen and touch	No pen or touch input is available for this display
+
+
+Here is my operating system:
+
+Edition	Windows 11 Home
+Version	24H2
+Installed on	‎2/‎21/‎2025
+OS build	26100.4061
+Experience	Windows Feature Experience Pack 1000.26100.84.0
+
+Here is the structure of my etm-framework repository:
+
+C:\Users\joeba\Documents\GitHub\etm-framework>tree /f /a
+Folder PATH listing for volume Windows
+Volume serial number is 2C83-F64F
+C:.
+|   .gitignore
+|   LICENSE
+|   README.md
+|   check_photon_physics.py
+|   etm_theory_foundation_outline.txt
+|   my operating system.txt
+|   requirements.txt
+|   run_etm.py
+|   setup.sh
+|   test_modules.py
+|
++---before_modules
+|   |   # Essential ETM nucleon Research Plan Secti.txt
+|   |   Deriving 3D Euclidean space from th.txt
+|   |   etm_framework.py
+|   |   etm_ontology_summary.md
+|   |   etm_trial_070_model_b_validation_nucleon_compatible_compact_10ticks.json
+|   |   etm_trial_beta_decay_validation_compact_100ticks.json
+|   |   etm_trial_neutron_internal_structure_compact_200ticks.json
+|
++---current_monolith
+|   |   # Essential ETM nucleon Research Plan Secti.txt
+|   |   Deriving 3D Euclidean space from th.txt
+|   |   etm_framework.py
+|   |   etm_ontology_summary.md
+|   |   etm_trial_070_model_b_validation_nucleon_compatible_compact_10ticks.json
+|   |   etm_trial_beta_decay_validation_compact_100ticks.json
+|   |   etm_trial_neutron_internal_structure_compact_200ticks.json
+|
++---docs
+|   |   AI_DEVELOPER_GUIDE.md
+|   |   QUICK_REFERENCE.md
+|   |
+|   \---etm_theory
+|       |   01_fundamental_definitions.md
+|       |   02_foundational_axioms.md
+|       |   03_fundamental_rules.md
+|       |   04_elementary_timing_patterns.md
+|       |   04_elementary_timing_patterns_outline.txt
+|       |   05_composite_timing_structures.md
+|       |   06_emergent_physical_phenomena.md
+|       |   07_mathematical_formalism.md
+|       |   08_correspondence_with_observations.md
+|       |   09_predictions_and_implications.md
+|       |   ETM_THEORY.md
+|
+\---etm
+    |   __init__.py
+    |   analysis.py
+    |   config.py
+    |   core.py
+    |   interface.py
+    |   particles.py
+    |   trials.py
+
+
+Here is the result of the last test that I ran:
+
+
+C:\Users\joeba\Documents\GitHub\etm-framework>python test_modules.py
+ETM Module Testing
+==================================================
+Testing Configuration Module...
+----------------------------------------
+✓ Basic config: connectivity=8
+✓ Kinetic scale: 1000.0
+✓ Version: 2.3 Nucleon Enhanced
+✓ Nucleon config: beta_decay=True
+
+Testing Core Module...
+----------------------------------------
+✓ Engine created: 8-connectivity
+✓ Lattice size: (30, 30, 30)
+✓ Center: (15, 15, 15)
+✓ Identity created: 123f0a48
+✓ Phase: 0.500 → 0.600
+✓ Neighbors: 8 for center
+✓ Echo fields: 27000 positions
+
+Testing Module Integration...
+----------------------------------------
+✓ Simulation ran 3 ticks
+✓ Final identities: 1
+✓ Integration successful!
+
+Testing Particles Module...
+----------------------------------------
+✓ Enhanced proton: 0.909 AGN survival
+✓ Neutron composite: 3 constituents
+✓ Stability testing: 0.355
+✓ Photon created: energy=13.6 eV
+✓ Photon-electron interaction: 0.405 strength, absorption: True
+✓ Photon varieties: visible (2.5 eV), hydrogen (13.6 eV)
+✓ Photon varieties: visible (2.5 eV), hydrogen (13.6 eV)
+✓ AGN survival: ✅ 90.9% (target: ≥90%)
+✓ Neutron structure: ✅ 3 constituents
+✓ Stability testing: ✅ 0.355
+
+🎉 ALL TESTS PASSED!
+✅ Configuration module working
+✅ Core module working
+✅ Module integration working
+✅ Particles module working
+✅ Enhanced proton AGN survival achieved
+✅ Nucleon internal structure functional
+
+Ready for next step: Extract trials and analysis modules
+
+
+I strongly suspect that as we explore ETM we are going to be led in entirely new directions that are very different than standard physics.  Let me give you an example:  As I was going through trials, AI was trying to duplicate the Pauli exclusion principle, and it was holding us up.  I suggested that maybe the Puali exclusion principle was emergent and was actually caused by detection apparatus, but that perhaps when electrons are left by themselves they are happy to get along.  Here, ETM was trying to tell us something, and we almost missed it because we were trying to force our results to match existing theory.
+
+So I don't want to assume things like bosons.  I suspect that they don't exist, just like I suspect that dark matter and/or dark energy don't exist.  I say these things tentatively, of course, because ultimately I must as a scientist go where the evidence leads.  So I could be wrong about this --- BUT I do not want to miss potential discoveries because of being locked into standard modeling.  I believe that ETM is much more subtle than this!  To give another example:  I have often thought that quantum interactions were extremely subtle and beautiful like complex music, and I suspected that high-energy particle accelerators might be obfuscating a lot, even as they taught us a lot.  As an analogy, let's suppose some aliens wanted to know why I really enjoy corvette automobiles.  So they take the automobile and smash it into a wall at 200 mph, and then try to discern from the wreckage what was attractive about the automobile.  My point is that I do not want the ETM development workflow to be assuming things like quarks and/or bosons prematurely.  I suspect we are going to be redefining a lot of things in very new ways.  I think it would be entirely appropriate to say something like "ETM explores the observational effects now attributed to bosons in another way ..... "  
+
+
+
+
+```

--- a/my operating system.txt
+++ b/my operating system.txt
@@ -31,108 +31,59 @@ Folder PATH listing for volume Windows
 Volume serial number is 2C83-F64F
 C:.
 |   .gitignore
-|   check_photon_physics.py
 |   LICENSE
 |   README.md
+|   check_photon_physics.py
+|   etm_theory_foundation_outline.txt
+|   my operating system.txt
+|   requirements.txt
 |   run_etm.py
+|   setup.sh
 |   test_modules.py
+|
++---before_modules
+|   |   # Essential ETM nucleon Research Plan Secti.txt
+|   |   Deriving 3D Euclidean space from th.txt
+|   |   etm_framework.py
+|   |   etm_ontology_summary.md
+|   |   etm_trial_070_model_b_validation_nucleon_compatible_compact_10ticks.json
+|   |   etm_trial_beta_decay_validation_compact_100ticks.json
+|   |   etm_trial_neutron_internal_structure_compact_200ticks.json
 |
 +---current_monolith
 |   |   # Essential ETM nucleon Research Plan Secti.txt
 |   |   Deriving 3D Euclidean space from th.txt
 |   |   etm_framework.py
-|   |   etm_logic_notebook.pdf
-|   |   etm_logic_notebook.tex
+|   |   etm_ontology_summary.md
 |   |   etm_trial_070_model_b_validation_nucleon_compatible_compact_10ticks.json
 |   |   etm_trial_beta_decay_validation_compact_100ticks.json
 |   |   etm_trial_neutron_internal_structure_compact_200ticks.json
-|   |   EUCLIDEAN TIMING MECHANICS (ETM) RESEARCH DEVELOPMENT PLAN.txt
+|
++---docs
+|   |   AI_DEVELOPER_GUIDE.md
+|   |   QUICK_REFERENCE.md
 |   |
-|   \---versions
-|       +---001
-|       |   |   corrected_trial_070.py
-|       |   |   etm_framework.py
-|       |   |   etm_ontology_summary.md
-|       |   |   etm_trial_070_compact_summary_10ticks.json
-|       |   |   EUCLIDEAN TIMING MECHANICS (ETM) RE.txt
-|       |   |   updated_corrected_trial_070.py
-|       |   |
-|       |   \---earlier results
-|       |           command prompt.txt
-|       |           corrected_trial_070.py
-|       |           etm_enhanced_trial_070_enhanced_dual_identity_coexistence_5ticks.json
-|       |           etm_enhanced_trial_070_properly_corrected_coexistence_10ticks.json
-|       |           etm_enhanced_trial_coexistence_stability_50ticks.json
-|       |           etm_enhanced_trial_detection_triggered_mutation_10ticks.json
-|       |
-|       +---002
-|       |   |   etm_framework.py
-|       |   |   etm_ontology_summary.md
-|       |   |   etm_trial_070_model_b_validation_compact_10ticks.json
-|       |   |   etm_trial_phase2_hydrogen_proper_compact_100ticks.json
-|       |   |   EUCLIDEAN TIMING MECHANICS (ETM) RESEARCH DEVELOPMENT PLAN.txt
-|       |   |   fixing the py file.txt
-|       |   |
-|       |   \---older
-|       |           etm_framework.py
-|       |           etm_trial_070_model_b_validation_compact_10ticks.json
-|       |           etm_trial_phase2_hydrogen_foundation_compact_50ticks.json
-|       |           EUCLIDEAN TIMING MECHANICS (ETM).txt
-|       |
-|       +---003
-|       |   |   etm_framework.py
-|       |   |   etm_trial_070_model_b_validation_compact_10ticks.json
-|       |   |   etm_trial_phase2a_particle_stability_compact_50ticks.json
-|       |   |   etm_trial_phase2_hydrogen_proper_compact_100ticks.json
-|       |   |   EUCLIDEAN TIMING MECHANICS (ETM) RESEARCH DEVELOPMENT PLAN.txt
-|       |   |   This is what appeared in my command.txt
-|       |   |
-|       |   \---older
-|       |           etm_trial_070_model_b_validation_compact_10ticks.json
-|       |
-|       +---004
-|       |   |   # ETM Nucleon Modeling Project - Tr.txt
-|       |   |   etm_framework.py
-|       |   |   etm_trial_070_model_b_validation_calibrated_compact_10ticks.json
-|       |   |   etm_trial_phase2a_particle_stability_enhanced_compact_50ticks.json
-|       |   |   etm_trial_phase2_hydrogen_calibrated_compact_100ticks.json
-|       |   |
-|       |   \---try diagostics
-|       |       |   etm_framework.py
-|       |       |   etm_trial_070_model_b_validation_calibrated_compact_10ticks.json
-|       |       |   etm_trial_phase2a_particle_stability_enhanced_compact_50ticks.json
-|       |       |   etm_trial_phase2_hydrogen_calibrated_compact_100ticks.json
-|       |       |
-|       |       \---older
-|       |               etm_trial_070_model_b_validation_calibrated_compact_10ticks.json
-|       |               etm_trial_phase2a_particle_stability_enhanced_compact_50ticks.json
-|       |               etm_trial_phase2_hydrogen_calibrated_compact_100ticks.json
-|       |
-|       +---005
-|       |       # Essential ETM nucleon Research Plan Secti.txt
-|       |       Deriving 3D Euclidean space from th.txt
-|       |       etm_framework.py
-|       |       etm_trial_070_model_b_validation_nucleon_compatible_compact_10ticks.json
-|       |       etm_trial_beta_decay_validation_compact_100ticks.json
-|       |       etm_trial_neutron_internal_structure_compact_200ticks.json
-|       |       EUCLIDEAN TIMING MECHANICS (ETM) RESEARCH DEVELOPMENT PLAN.txt
-|       |
-|       \---006
-|               modularization_request.txt
+|   \---etm_theory
+|       |   01_fundamental_definitions.md
+|       |   02_foundational_axioms.md
+|       |   03_fundamental_rules.md
+|       |   04_elementary_timing_patterns.md
+|       |   04_elementary_timing_patterns_outline.txt
+|       |   05_composite_timing_structures.md
+|       |   06_emergent_physical_phenomena.md
+|       |   07_mathematical_formalism.md
+|       |   08_correspondence_with_observations.md
+|       |   09_predictions_and_implications.md
+|       |   ETM_THEORY.md
 |
 \---etm
+    |   __init__.py
     |   analysis.py
     |   config.py
     |   core.py
     |   interface.py
     |   particles.py
     |   trials.py
-    |   __init__.py
-    |
-    \---__pycache__
-            config.cpython-313.pyc
-            core.cpython-313.pyc
-            particles.cpython-313.pyc
 
 
 Here is the result of the last test that I ran:


### PR DESCRIPTION
## Summary
- install `numpy`
- integrate entire operating notes into README
- encourage larger node counts for simulations

## Testing
- `python test_modules.py`


------
https://chatgpt.com/codex/tasks/task_b_684474f1680483309e6f8a36587daeeb