### PR TITLE
Add annihilation trial and expand cosmology text

### DIFF
--- a/docs/etm_theory/09_predictions_and_implications.md
+++ b/docs/etm_theory/09_predictions_and_implications.md
@@ -91,43 +91,63 @@ The following predictions highlight unique experimental signatures of Euclidean 
 
 ### 9.3 Cosmological and Large-Scale Implications
 
-The discrete timing foundations of ETM extend naturally from particle-scale
-phenomena to cosmological structure.  The following implications describe how
-large-scale observations can be reinterpreted within the timing-mechanics
-framework.
+The deterministic timing framework introduced in Chapters&nbsp;1–7 applies not
+only to particle dynamics but also to the evolution of the Universe as a
+whole.  Because ETM treats energy as localized timing strain and all forces as
+emergent recruiter interactions, large-scale structure follows directly from the
+same update rules that govern microscopic behavior.  The implications below are
+formulated so that cosmological simulations can be constructed directly from the
+ETM engine described in `etm/core.py`.
 
 #### Implication 9.9: Emergent Large-Scale Structure from Timing Networks
 
-**Statement**: Galaxy formation and clustering result from long-range phase
-correlation in recruiter networks (Rules&nbsp;R10–R17) seeded by primordial
-fluctuations (Definition&nbsp;4.21).  Massive structures arise where echo-field
-reinforcement produces stable timing patterns over cosmic timescales.
+**Statement**: Galaxy formation and clustering arise from long-range phase
+correlations in recruiter networks (Rules&nbsp;R10–R17) seeded by primordial
+fluctuations (Definition&nbsp;4.21).  Regions where echo-field reinforcement is
+constructive form gravitationally bound systems over cosmic timescales.
 
-**Consequence**: Dark-matter halos are interpreted as regions of dense,
-undetected timing activity rather than unseen particles.  Simulations must track
-recruiter coupling across megaparsec scales using lattice tiling to predict
-galaxy distribution statistics.
+**Consequence**: Dark-matter halos correspond to volumes of high recruiter
+activity that remain largely undetected due to limited local phase alignment.
+Cosmological simulations must therefore tile the ETM lattice over megaparsec
+scales and explicitly propagate recruiter links to reproduce observed galaxy
+correlation functions.
 
 #### Implication 9.10: Cosmic Element Recycling via Enhanced Proton Patterns
 
-**Statement**: Enhanced protons (Definition&nbsp;4.17) survive active galactic
-nucleus ejection with high probability, enabling metal-rich outflows to seed new
-star formation across intergalactic distances.
+**Statement**: Enhanced proton timing patterns (Definition&nbsp;4.17) are
+predicted to survive active galactic nucleus (AGN) ejection with high
+probability.  These long-lived patterns transport heavy elements far from their
+origin galaxies before decaying or reintegrating into new structures.
 
-**Consequence**: Element abundance gradients observed in deep-field surveys can
-be reproduced by running cosmological ETM simulations with validated AGN
-survival parameters.  This provides a deterministic alternative to stochastic
-feedback models in standard cosmology.
+**Consequence**: Deep-field abundance gradients can be modeled by injecting
+validated enhanced proton parameters into large-scale ETM simulations.  This
+approach replaces stochastic feedback prescriptions with deterministic timing
+rules, offering precise predictions for metal enrichment of the intergalactic
+medium.
 
 #### Implication 9.11: CMB Anisotropies from Lattice Boundary Conditions
 
-**Statement**: The cosmic microwave background (CMB) temperature fluctuations
-arise from boundary-induced phase shifts in the early-universe lattice
-(Mathematical Framework&nbsp;7.1) rather than quantum inflationary noise.
+**Statement**: Temperature variations in the cosmic microwave background (CMB)
+originate from boundary-induced phase shifts of the primordial ETM lattice
+(Mathematical Framework&nbsp;7.1) rather than from stochastic inflationary
+fluctuations.
 
-**Consequence**: Predicted multipole spectra depend sensitively on the global
-lattice dimensions and tick resolution.  By adjusting these parameters within
-ETM simulations, CMB anisotropy patterns can be matched without invoking
-inflation.
+**Consequence**: The predicted multipole spectrum is a direct function of the
+global lattice dimensions and tick resolution.  By tuning these simulation
+parameters, ETM reproduces observed CMB anisotropies without invoking an
+inflationary epoch.
+
+#### Implication 9.12: Expansion as Global Phase Drift
+
+**Statement**: Cosmic expansion corresponds to a uniform drift in lattice phase
+offsets driven by cumulative timing strain energy (Rules&nbsp;R7–R9).  The
+observed Hubble parameter reflects the rate of this global phase divergence
+rather than motion through a continuous space.
+
+**Consequence**: ETM predicts subtle departures from standard expansion models
+when large-scale timing strain is perturbed, for example by massive recruiter
+networks.  Accurate cosmological simulations must therefore couple local timing
+strain evolution to global phase drift when computing redshift–distance
+relations.
 
 

--- a/trials/001_electron_positron_annihilaton/electron_positron_annihilation.md
+++ b/trials/001_electron_positron_annihilaton/electron_positron_annihilation.md
@@ -1,0 +1,29 @@
+# Electron–Positron Annihilation Trial
+
+This trial proposes a minimal ETM simulation of an electron and a positron initially at rest and separated by a small but finite lattice distance. The goal is to examine how ETM chirality generates an effective electromagnetic attraction and to track the timing-strain energy released as photons when the particles annihilate.
+
+## Objectives
+
+1. **Validate Charge Interaction** – Show that opposite chirality patterns accelerate toward each other under the ETM timing rules, providing an information-theoretic analogue to the Coulomb force. Measuring the approach rate offers a pathway to calibrate an ETM value analogous to the Coulomb constant.
+2. **Energy Accounting** – Confirm that the total timing strain before annihilation equals the energy carried away by the emergent photon patterns. This demonstrates conservation of energy within ETM and links photon creation to localized timing reorganization.
+3. **Photon Generation Mechanism** – Record how the annihilation event produces photon timing patterns. Compare the resulting frequencies to those predicted by the strain in the initial electron–positron system.
+
+## Simulation Outline
+
+1. **Initial Conditions**
+   - Place an electron identity and a positron identity on opposite sides of the lattice center, each at rest with respect to the simulation frame.
+   - Set the initial separation large enough that immediate annihilation does not occur but small enough that chirality attraction draws them together within a manageable number of ticks.
+2. **Dynamics**
+   - Run the ETM engine with detection triggered at each tick. Track positions, phases, and timing strain of both identities as they move.
+   - Monitor the lattice for recruitment patterns indicating photon creation during the collision.
+3. **Data Collection**
+   - Record the tick number of annihilation, total strain energy immediately before the event, and the energy distribution among emitted photons.
+   - Analyze whether the approach trajectory matches the expected $1/r^2$ form of a Coulomb-like force in the ETM framework.
+
+## Expected Outcomes
+
+- A quantitative demonstration that ETM chirality leads to an effective attractive force consistent with classical charge behavior.
+- Conservation of timing strain energy, with photons carrying away the precise amount released by the annihilation.
+- Insight into how ETM constructs photon identities from timing strain reorganization, informing further development of the photon model.
+
+Documenting this trial will guide improvements to the ETM particle interaction rules and support future derivations of electromagnetic constants from first principles.


### PR DESCRIPTION
## Summary
- add a trial description for electron–positron annihilation
- expand Section 9.3 on cosmological implications with new subsection and refined wording

## Testing
- `python test_modules.py`

------
https://chatgpt.com/codex/tasks/task_b_6844820c06b08330a9298e613b811773