### PR TITLE
Run trials and update velocity docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The repository follows a two-phase development strategy:
 1. **Codex Validation** – implement each simulation using lattices up to about 30×30×30 nodes to ensure code correctness in this environment.
 2. **Home Computer Scale-Up** – run the same simulations on larger lattices (50³ or more) for extended durations to refine constants.
 
-See `docs/ETM_SIMULATION_RESEARCH_PLAN.md` and `docs/ETM_CONSTANT_DERIVATION_PLAN.md` for details. Both documents emphasize that after initialization **all motion and interactions must arise exclusively from ETM logic**.
+See `docs/ETM_SIMULATION_RESEARCH_PLAN.md` and `docs/ETM_CONSTANT_DERIVATION_PLAN.md` for details. Both documents emphasize that after initialization **all motion and interactions must arise exclusively from ETM logic**. Any velocity specified for an identity is used only once at creation to shift its starting position; further movement must result solely from ETM return rules.
 
 ## Development Guidelines
 - Preserve validated parameters in `etm/config.py`

--- a/docs/AI_DEVELOPER_GUIDE.md
+++ b/docs/AI_DEVELOPER_GUIDE.md
@@ -68,7 +68,9 @@ Recent trials illustrate core functionality:
 
 ## 7. Research Guidelines
 - Conform to the ETM Simulation Research Plan (`docs/ETM_SIMULATION_RESEARCH_PLAN.md`).
-- Maintain the rule that **all dynamics after initialization arise from ETM logic alone**.
+ - Maintain the rule that **all dynamics after initialization arise from ETM logic alone**.
+   Any `velocity` attribute is applied once at creation to set an initial displacement
+   and is then cleared so that subsequent movement results only from ETM return rules.
 - Record simulation environments and parameters so results can be reproduced.
 
 By following these practices, researchers can build upon the ETM framework while preserving prior validations.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -30,7 +30,7 @@ Results are stored in JSON format within the trial folder and explained in `note
 - 008 Electron energy change from absorption
 
 ## Fundamental Rule
-All motion, propagation, and effects after initialization must emerge only from ETM logic—no explicit velocity functions or external forces are allowed.
+All motion, propagation, and effects after initialization must emerge only from ETM logic—no explicit velocity functions or external forces are allowed. Any `velocity` set on an identity is applied only at the first tick to establish an initial displacement and is then cleared.
 
 For detailed guidance see `docs/AI_DEVELOPER_GUIDE.md`, the full `ETM_SIMULATION_RESEARCH_PLAN.md`, and `docs/ETM_CONSTANT_DERIVATION_PLAN.md`.
 

--- a/docs/etm_theory/03_fundamental_rules.md
+++ b/docs/etm_theory/03_fundamental_rules.md
@@ -3386,6 +3386,9 @@ def calculate_kinetic_energy(identity):
     base_kinetic = identity.delta_theta * KINETIC_SCALE_FACTOR
     
     # Motion-dependent kinetic energy if identity has velocity
+    # A velocity may be specified only for initialization. It is applied once
+    # at the first tick and then cleared, so subsequent motion depends solely on
+    # return eligibility.
     if hasattr(identity, 'velocity') and identity.velocity:
         velocity_magnitude = calculate_velocity_magnitude(identity.velocity)
         motion_kinetic = 0.5 * EFFECTIVE_MASS_SCALE * velocity_magnitude**2

--- a/trials/001_electron_positron_annihilaton/electron_positron_annihilation.md
+++ b/trials/001_electron_positron_annihilaton/electron_positron_annihilation.md
@@ -14,7 +14,7 @@ This trial proposes a minimal ETM simulation of an electron and a positron initi
    - Place an electron identity and a positron identity on opposite sides of the lattice center, each at rest with respect to the simulation frame.
    - Set the initial separation large enough that immediate annihilation does not occur but small enough that chirality attraction draws them together within a manageable number of ticks.
 2. **Dynamics**
-   - Each identity is given a velocity toward the lattice center. The engine moves them automatically every tick via the new `move_identities` step.
+   - Each identity is given a small velocity toward the lattice center. This velocity is applied only once at initialization to shift the starting position. Subsequent motion arises solely from the ETM return rules—there is no persistent movement step.
    - Detection is triggered each tick and records collisions, timing strain, and emitted photon identities.
    - Monitor the lattice for recruitment patterns indicating photon creation during the collision.
 3. **Data Collection**

--- a/trials/003_photon_propagation/photon_propagation.md
+++ b/trials/003_photon_propagation/photon_propagation.md
@@ -1,12 +1,12 @@
 # Photon Propagation Test
 
-This trial verifies that photon identities created by the engine propagate one
-lattice step per tick according to their velocity.
+This trial verifies that photon identities created by the engine shift position once at initialization when a velocity is specified. Subsequent ticks obey ETM return logic without any persistent velocity.
 
 ## Procedure
 
 1. Initialize the engine with the validated foundation configuration.
 2. Create a visible-light photon at the lattice center with velocity `(1, 0, 0)`.
+   This velocity is applied only on the first tick to displace the photon by one lattice unit.
 3. Run the simulation for four ticks, recording the photon's position each tick.
 4. Write the trajectory to `photon_propagation_results.json`.
 

--- a/trials/011_magnetic_field/notes.md
+++ b/trials/011_magnetic_field/notes.md
@@ -4,7 +4,7 @@ This trial initiates **Stage 4 – Magnetic Interaction** of the *ETM Simulatio
 
 ## Plan
 - **Objective**: Record echo-field values around a moving electron to quantify the magnetic-like pattern of a travelling charge.
-- **Setup**: A `(21,21,21)` lattice with neutral recruiters at every node. An electron begins near the left boundary with velocity `(1,0,0)` so it drifts along the $x$‑axis. All reinforcement and motion after initialization follow ETM rules.
+- **Setup**: A `(21,21,21)` lattice with neutral recruiters at every node. An electron begins near the left boundary with velocity `(1,0,0)` applied only at the first tick to offset its starting position. All reinforcement and motion after initialization follow ETM rules.
 - **Method**:
   1. At each tick reinforce the echo field at the electron position and call `advance_tick` to update phases and move the particle.
   2. Record echo strengths one lattice step above and below the electron in the $y$ direction.

--- a/trials/011_magnetic_field/run_trial.py
+++ b/trials/011_magnetic_field/run_trial.py
@@ -38,7 +38,7 @@ def run_trial():
     for _ in range(config.max_ticks):
         # reinforce echo at electron position
         engine.echo_fields[electron.position].add_reinforcement(1.0)
-        # advance the ETM engine (moves electron via velocity)
+        # advance the ETM engine (initial velocity applied only once)
         engine.advance_tick()
 
         pos = electron.position

--- a/trials/012_magnetic_deflection/notes.md
+++ b/trials/012_magnetic_deflection/notes.md
@@ -4,10 +4,10 @@ This trial continues **Stage 4 – Magnetic Interaction** of the *ETM Simulatio
 
 ## Plan
 - **Objective**: Demonstrate that a moving electron generates a lateral timing disturbance strong enough to alter the path of a neighbouring electron.
-- **Setup**: A `(21,21,21)` lattice with neutral recruiters everywhere. Electron A starts near the left boundary moving along the $x$‑axis. Electron B is placed two lattice units above its path with no preset velocity. All motion after initialization arises solely from echo gradients.
+- **Setup**: A `(21,21,21)` lattice with neutral recruiters everywhere. Electron A starts near the left boundary with velocity `(1,0,0)` applied only on the first tick so it begins moving along the $x$‑axis. Electron B is placed two lattice units above its path with no preset velocity. All motion after initialization arises solely from echo gradients.
 - **Method**:
   1. Reinforce the echo field at both electron positions each tick.
-  2. Advance the ETM engine. Electron A moves via its initial velocity; Electron B moves toward the neighbour with the largest echo from Electron A.
+  2. Advance the ETM engine. Electron A is displaced once by its initial velocity while Electron B moves toward the neighbour with the largest echo from Electron A.
   3. Record both trajectories in `magnetic_deflection_results.json`.
 
 ## Results

--- a/trials/013_parallel_current/notes.md
+++ b/trials/013_parallel_current/notes.md
@@ -4,11 +4,11 @@ This trial advances **Stage 4 – Magnetic Interaction** of the *ETM Simulation
 
 ## Plan
 - **Objective**: Observe the lateral approach of two electrons travelling side by side along the $x$‑axis.
-- **Setup**: A $(21,21,21)$ lattice populated with neutral recruiters. Electrons A and B start at $(1,y_0,z_0)$ and $(1,y_0+2,z_0)$ with initial velocity $(1,0,0)$. Their positions are adjusted each tick toward the neighbour with the strongest echo, representing magnetic influence.
+- **Setup**: A $(21,21,21)$ lattice populated with neutral recruiters. Electrons A and B start at $(1,y_0,z_0)$ and $(1,y_0+2,z_0)$ with initial velocity $(1,0,0)$. This velocity is applied only on the first tick to place them in motion; thereafter the return algorithm moves each electron toward the neighbour with the strongest echo, representing magnetic influence.
 - **Method**:
   1. Reinforce the echo field at both electron positions.
   2. Move each electron to the neighbouring node with the largest echo value.
-  3. Advance the ETM engine so velocity shifts both electrons forward along $x$.
+  3. Advance the ETM engine so the return logic shifts both electrons forward along $x$ after the initial displacement.
   4. Record the positions for ten ticks in `parallel_current_results.json`.
 
 ## Results


### PR DESCRIPTION
## Summary
- confirm all validation trials run with new ETM logic
- document that initial velocity only displaces once in trial descriptions
- clarify single-use velocity in moving electron scripts

## Testing
- `pip install -r requirements.txt`
- `python test_modules.py`
- `for d in trials/*; do python $d/run_trial.py; done`

------
https://chatgpt.com/codex/tasks/task_b_6845e14481188330b300418ffd97113a