### PR TITLE
Update docs for backward compatibility and start proton refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ python test_modules.py
 ```
 Expected output is `ALL TESTS PASSED!` confirming that the configuration, core engine, particles, and integration tests run correctly.
 
+### Backward Compatibility
+As ETM logic improves the particle timing patterns may be redefined. Earlier trials must still run successfully under the updated code. Backward compatibility therefore refers to preserving the **behavior** of validated experiments, not freezing the internal definitions of particles.
+
 ## Running Validation Trials
 Each numbered folder in `trials/` contains scripts and documentation for a specific simulation.
 To execute a trial run:
@@ -80,9 +83,12 @@ Recent trials include:
   approach and repulsion)
 
 ## Research Plan
-The repository follows a two-phase development strategy:
+The repository follows a staged development strategy:
 1. **Codex Validation** – implement each simulation using lattices up to about 30×30×30 nodes to ensure code correctness in this environment.
 2. **Home Computer Scale-Up** – run the same simulations on larger lattices (50³ or more) for extended durations to refine constants.
+3. **Extended Scale and Neutrino Exploration** – explore lattices approaching 10⁸ nodes while testing neutrino timing patterns.
+4. **Particle Resolution Studies** – vary lattice resolution and refine particle definitions to determine minimal stable node counts.
+5. **Composite Particle Review** – beginning with trial 047, revisit protons and other composites to optimize their timing patterns and verify backward compatibility.
 
 See `docs/ETM_SIMULATION_RESEARCH_PLAN.md` and `docs/ETM_CONSTANT_DERIVATION_PLAN.md` for details. Both documents emphasize that after initialization **all motion and interactions must arise exclusively from ETM logic**. Any velocity specified for an identity is used only once at creation to shift its starting position; further movement must result solely from ETM return rules.
 
@@ -90,6 +96,7 @@ See `docs/ETM_SIMULATION_RESEARCH_PLAN.md` and `docs/ETM_CONSTANT_DERIVATION_PLA
 - Preserve validated parameters in `etm/config.py`
 - Add new features in modular form with accompanying tests
 - Document all simulation results in the `docs` and `trials` directories
+- When particle definitions or rules change, rerun earlier successful trials to confirm backward compatibility.
 
 The ETM framework is released under the MIT license. Researchers may reproduce and extend the work provided that the underlying timing logic is maintained.
 

--- a/docs/AI_DEVELOPER_GUIDE.md
+++ b/docs/AI_DEVELOPER_GUIDE.md
@@ -5,9 +5,12 @@ This guide explains how to work with the Euclidean Timing Mechanics simulation l
 ## 1. Framework Overview
 ETM represents particles as timing patterns across a discrete lattice. Node interactions alter local tick rates, and all propagation arises from this timing logic. After initialization no velocity or force is imposed externally; motion results solely from the ETM update rules.
 
-Development proceeds in two phases:
+Development proceeds in several phases:
 1. **Codex Validation** – use lattices up to about 30×30×30 nodes to verify each simulation in this repository.
 2. **Home Computer Scale-Up** – once stable, rerun the simulations on larger lattices (50³ or more) for extended periods to refine constant measurements.
+3. **Extended Scale and Neutrino Exploration** – probe lattices approaching 10⁸ nodes while testing neutrino timing patterns.
+4. **Particle Resolution Studies** – vary lattice resolution and adjust particle definitions to identify minimal stable node counts.
+5. **Composite Particle Review** – starting with trial 47, revisit protons and other composites while ensuring backward compatibility by re-running earlier trials.
 
 The file `docs/ETM_CONSTANT_DERIVATION_PLAN.md` details how these simulations map to fundamental constants.
 
@@ -75,7 +78,10 @@ Recent trials illustrate core functionality:
 
 By following these practices, researchers can build upon the ETM framework while preserving prior validations.
 
-## 8. Running Extended Simulations
+## 8. Backward Compatibility
+Particle timing patterns will evolve as the theory improves. When definitions change, rerun all previously successful trials. Backward compatibility is achieved if those experiments still produce their expected outcomes, even though the internal particle patterns may differ from earlier versions.
+
+## 9. Running Extended Simulations
 Phase 2 experiments may require hundreds of ticks on lattices larger than 50³.
 Each `run_trial.py` script accepts `--ticks` and `--size` arguments to control
 these parameters. On Windows you can launch a long run in the background with:

--- a/docs/ETM_CONSTANT_DERIVATION_PLAN.md
+++ b/docs/ETM_CONSTANT_DERIVATION_PLAN.md
@@ -47,6 +47,9 @@ This document outlines a progressive set of simulations for defining Euclidean T
 ## Development Phases
 1. **Codex Validation** – Implement all stages on lattices up to about 30×30×30 nodes to verify correctness within this chat environment.
 2. **Home Computer Runs** – Once the code is stable, execute the same simulations on larger lattices (50^3 or more) for extended durations. Use multiprocessing or lightweight scripts so the computer remains responsive.
+3. **Extended Scale and Neutrino Exploration** – explore lattices approaching 10⁸ nodes while testing neutrino patterns.
+4. **Particle Resolution Studies** – vary lattice resolution and refine particle definitions.
+5. **Composite Particle Review** – revisit proton and neutron designs starting with trial 47, ensuring earlier trials remain valid.
 
 Each stage refines the constants' precision. Achieving four significant digits is expected only when simulations approach 10^7–10^8 nodes and run long enough to average fluctuations.
 

--- a/docs/ETM_SIMULATION_RESEARCH_PLAN.md
+++ b/docs/ETM_SIMULATION_RESEARCH_PLAN.md
@@ -4,6 +4,9 @@ This document outlines a step-by-step strategy for determining the ETM equivalen
 ### Fundamental ETM Dynamics Rule
 All motion, propagation, and effects MUST take place only according to ETM logic, including the propagation of light. It is ok to start an identity like an electron with an initial velocity, but after the start, it must proceed disappearing from some nodes and returning in other nodes purely and exclusively from ETM logic, NOT from some arbitrarily defined velocity function, and the same goes for the propagation of light. In fact, every single change in the simulation must only occur due to ETM logic after the start. This must be a standing rule in all testing.
 
+### Backwards Compatibility Policy
+Particle definitions are expected to evolve as ETM logic is refined. Backwards compatibility therefore means that the **same categories of experiments** must still execute successfully when the code and particle patterns are updated. When any rule or definition changes, rerun prior validated trials to ensure they still pass—even though the internal particle designs may have changed. Earlier results remain valid if reproduced under the new logic without requiring identical timing patterns.
+
 ### Development Phases
 - **Phase 1 – Codex Validation**: Implement all stages using lattices up to about 30×30×30 to ensure functionality in this chat environment.
 - **Phase 2 – Home Computer Scale-Up**: Once code is stable, run larger lattices (50³ or greater) on your personal machine for extended simulations.
@@ -116,8 +119,11 @@ All eighteen trials were rerun after implementing the single-use velocity policy
 Phase 3 covered trials 035–044. These runs explored lattices approaching 10^8 nodes and tested neutrino timing patterns alongside alternative echo-field updates. All simulations continued to evolve strictly from ETM rules after initialization. The neutrino pattern now supports a simple oscillation method that cycles the flavor between electron, muon, and tau types based on the current tick.
 
 ### Phase 4 Plan
-Phase 4 begins with trial 045. The priority is determining the lattice resolution needed for stable particle behavior. Simulations will vary overall lattice size while keeping particle definitions unchanged to see how many nodes best express each identity. About ten trials are anticipated before constants can be derived with four-digit precision.
+Phase 4 begins with trial 045. The priority is determining the lattice resolution needed for stable particle behavior. Simulations will vary overall lattice size while refining particle definitions to see how many nodes best express each identity. Earlier successful trials must still pass after these updates, providing backward compatibility even when the particle patterns change. About ten trials are anticipated before constants can be derived with four-digit precision.
 
 During this phase we will also test scaling factors for the particle patterns themselves. By adjusting how many lattice nodes compose each identity, we hope to discover the minimum node count that still reproduces stable motion and interactions. Resolution studies will compare different lattice sizes and particle scales to isolate which combination most closely matches known physical behavior without importing external theory.
 
 Early results from trial 046 confirm that doubling the electron pattern scale retains stability on short runs. Going forward each trial will prioritize scanning particle scales—particularly electrons and protons—while incrementally increasing lattice resolution toward the target 51×51×51 and beyond.
+
+### Phase 5 Plan
+Phase 5 begins with trial 047. The immediate goal is to revisit the proton and other composite particles to determine their optimal node counts and timing patterns. Definitions of the proton, neutron, and the charged leptons will be refined based on simulation results. Each change to the particle patterns must be accompanied by rerunning earlier successful trials to verify backward compatibility. Once stable definitions are achieved we will resume deriving the ETM analogues of the physical constants using the updated models.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -63,6 +63,8 @@ Results are stored in JSON format within the trial folder and explained in `note
 ## Fundamental Rule
 All motion, propagation, and effects after initialization must emerge only from ETM logic—no explicit velocity functions or external forces are allowed. Any `velocity` set on an identity is applied only at the first tick to establish an initial displacement and is then cleared.
 
+When particle definitions or rules are refined, rerun earlier successful trials. Backward compatibility is satisfied if those experiments still succeed even though the particle patterns may have changed.
+
 For detailed guidance see `docs/AI_DEVELOPER_GUIDE.md`, the full `ETM_SIMULATION_RESEARCH_PLAN.md`, and `docs/ETM_CONSTANT_DERIVATION_PLAN.md`.
 Use the optional `--sleep` argument in any trial's run script to slow down each tick if a background run needs to stay responsive.
 
@@ -72,3 +74,4 @@ Use the optional `--sleep` argument in any trial's run script to slow down each 
 3. **Extended Scale and Neutrino Exploration** – large lattices with neutrino patterns (phase 3).
 4. **Particle Resolution Studies** – vary lattice size to determine how many nodes best express each particle (phase 4).
    Priority: scan particle scale factors alongside lattice resolution to establish the minimal stable node count for each identity.
+5. **Composite Particle Review** – beginning with trial 47, refine proton and neutron patterns while rerunning earlier trials to verify backward compatibility.

--- a/trials/047_proton_resolution_scan_5/notes.md
+++ b/trials/047_proton_resolution_scan_5/notes.md
@@ -1,0 +1,24 @@
+# Trial 047 – Phase 5 – Proton Resolution Scan
+
+This trial begins the composite particle review phase. We vary the number of lattice nodes assigned to the proton pattern to determine the smallest stable configuration.
+
+## Plan
+- **Engine**: `ConfigurationFactory.validated_foundation_config("proton_resolution")`
+- **Lattice**: default `51×51×51` (override with `--size`)
+- **Ticks**: default `200` (override with `--ticks`)
+- **Scale**: multiplies the proton pattern offsets
+
+Run with for example:
+```bash
+python run_trial.py --ticks 200 --size 51 --scale 2
+```
+
+## Results
+Placeholder output from a short Codex run on a 21³ lattice with `scale=2`:
+```json
+{
+  "scale": 2,
+  "positions": [[10,10,10],[10,10,10],[10,10,10]]
+}
+```
+See `proton_resolution_scan_5_results.json` for full data.

--- a/trials/047_proton_resolution_scan_5/run_trial.py
+++ b/trials/047_proton_resolution_scan_5/run_trial.py
@@ -1,0 +1,52 @@
+import json
+import os
+import sys
+import argparse
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, ROOT_DIR)
+
+from etm.config import ConfigurationFactory
+from etm.core import ETMEngine, Identity
+from etm.particles import ParticleFactory
+
+
+def run_trial(max_ticks: int = 200, lattice_size=(51, 51, 51), scale: int = 1):
+    config = ConfigurationFactory.validated_foundation_config("proton_resolution")
+    config.max_ticks = max_ticks
+    config.lattice_size = lattice_size
+    engine = ETMEngine(config)
+
+    center = engine.center
+    p_pattern = ParticleFactory.create_proton(scale=scale)
+    proton = Identity(
+        module_tag="PROTON",
+        ancestry="pos",
+        theta=0.0,
+        delta_theta=0.05,
+        position=center,
+    )
+    proton.fundamental_particle = p_pattern
+    engine.identities.append(proton)
+
+    data = {"scale": scale, "positions": [list(proton.position)]}
+    for _ in range(config.max_ticks):
+        engine.advance_tick()
+        data["positions"].append(list(proton.position))
+        if engine.tick % 50 == 0:
+            print(f"Tick {engine.tick}/{config.max_ticks}")
+
+    result_path = os.path.join(os.path.dirname(__file__), "proton_resolution_scan_5_results.json")
+    with open(result_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+    print(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Proton resolution scan")
+    parser.add_argument("--ticks", type=int, default=200, help="Maximum ticks to run")
+    parser.add_argument("--size", type=int, default=51, help="Cubic lattice dimension")
+    parser.add_argument("--scale", type=int, default=1, help="Proton pattern scale factor")
+    args = parser.parse_args()
+    run_trial(max_ticks=args.ticks, lattice_size=(args.size, args.size, args.size), scale=args.scale)


### PR DESCRIPTION
## Summary
- clarify backward compatibility in research plan and docs
- expand development phases and add backward compatibility notes in README and docs
- add proton resolution scan trial to begin phase 5

## Testing
- `python test_modules.py`

------
https://chatgpt.com/codex/tasks/task_b_684818c185c08330aa5f970cf880eac1